### PR TITLE
feature/DP-751: Settings UI

### DIFF
--- a/.jestrc.json
+++ b/.jestrc.json
@@ -2,5 +2,8 @@
   "collectCoverage": true,
   "collectCoverageFrom": [
     "src/main/javascript/*"
+  ],
+  "setupFiles": [
+    "./src/test/setup.js"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "main": "lib/main/javascript/index.js",
   "scripts": {
     "dev": "dpat server .",
-    "package": "dpat clean . && dpat compile . && dpat verify ./dist && dpat package .",
-    "test": "dpat test ."
+    "lint": "eslint src/main/javascript/* --ext .js,.jsx --cache --cache-location=.cache/eslint",
+    "lint:fix": "npm run lint -- --fix",
+    "package": "dpat clean . && dpat compile . && dpat bundle-installer . && dpat verify ./dist && dpat package .",
+    "test": "dpat test .",
+    "version": "version-changelog CHANGELOG.md && changelog-verify CHANGELOG.md && git add CHANGELOG.md"
   },
   "repository": {
     "type": "git",
@@ -28,25 +31,58 @@
   },
   "homepage": "https://github.com/deskpro/apps-youtrack#readme",
   "deskpro": {
-    "version": "2.1.0",
+    "version": "2.3.0",
     "title": "Youtrack",
     "isSingle": true,
     "scope": "agent",
+    "storage": [
+      {
+        "name": "oauth:youtrack",
+        "isBackendOnly": false,
+        "permRead": "EVERYBODY",
+        "permWrite": "OWNER"
+      }
+    ],
+    "settings": [
+      {
+        "name": "youtrackClientId",
+        "defaultValue": "",
+        "title": "The consumer key",
+        "required": true,
+        "type": "text"
+      },
+      {
+        "name": "youtrackHubUrl",
+        "defaultValue": "",
+        "title": "The Youtrack HUB url",
+        "required": true,
+        "type": "text"
+      },
+      {
+        "name": "urlRedirect",
+        "defaultValue": "",
+        "title": "The Youtrack redirect URL",
+        "required": true,
+        "type": "text"
+      }
+    ],
     "targets": [
       {
         "target": "ticket-sidebar",
         "url": "html/index.html"
       }
     ],
-    "settings": [],
     "deskproApiTags": [],
     "externalApis": []
   },
   "devDependencies": {
     "@deskpro/apps-dpat": "^0.9.6",
+    "@deskpro/apps-installer": "github:deskpro/apps-installer#v0.4.2",
     "@deskpro/apps-sdk-core": "^1.0.0-beta.26",
     "@deskpro/apps-sdk-react": "0.2.7",
     "babel-eslint": "^8.0.1",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-15": "^1.0.5",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^15.0.2",
     "eslint-plugin-compat": "^1.0.4",
@@ -54,6 +90,7 @@
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-react": "^7.1.0",
+    "lodash": "4.17.4",
     "react": "^15.6.2",
     "react-dom": "^15.6.2",
     "react-test-renderer": "^15.6.2"

--- a/src/installer/javascript/ScreenSettings.js
+++ b/src/installer/javascript/ScreenSettings.js
@@ -1,0 +1,97 @@
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import get from 'lodash/get';
+import isError from 'lodash/isError';
+
+export default class ScreenSettings extends React.Component {
+
+  static propTypes = {
+    finishInstall: PropTypes.func.isRequired,
+    installType: PropTypes.string.isRequired,
+    settings: PropTypes.array.isRequired,
+    values: PropTypes.array.isRequired,
+    settingsForm: PropTypes.func.isRequired,
+    dpapp: PropTypes.object.isRequired
+  };
+
+  constructor() {
+    super();
+    this.state = {
+      oauthSettings: null,
+      error: null
+    };
+  }
+
+  componentDidMount() {
+    const { oauth } = this.props.dpapp;
+
+    oauth.settings('youtrack')
+      .then(oauthSettings => this.setState({ oauthSettings, error: null }))
+      .catch(error => this.setState({ oauthSettings: null, error: new Error(error) }));
+  }
+
+  onSettings(settings) {
+    const { oauth } = this.props.dpapp;
+    const { finishInstall } = this.props;
+    const providerName = 'youtrack';
+
+    // retrieve the oauth proxy settings for jira
+    oauth.settings(providerName)
+      .then(oauthSettings => {
+        const connectionProps = {
+          providerName,
+          urlRedirect: oauthSettings.urlRedirect,
+          urlAuthorize: `${settings.youtrackHubUrl}/api/rest/oauth2/auth`,
+          urlAccessToken: `${settings.youtrackHubUrl}/api/rest/oauth2/token`,
+          clientId: `${settings.youtrackClientId}`,
+          clientSecret: ''
+        };
+        return oauth.register(providerName, connectionProps).then(() => connectionProps);
+      })
+      .then(connectionProps => (
+        oauth.access(providerName)
+          .then(({ oauth_token, oauth_token_secret }) => ({
+            ...connectionProps, token: oauth_token, tokenSecret: oauth_token_secret
+          }))
+      ))
+      // register again the connection, this time with the token
+      .then(connectionProps => oauth.register('youtrack', connectionProps))
+      .then(() => finishInstall(settings).then(({ onStatus }) => onStatus()))
+      .catch(error => new Error(error)); // TODO display errors
+  }
+
+  render() {
+    const { settings, values, finishInstall, settingsForm: SettingsForm } = this.props;
+    const redirectUrl = get(this.state, 'oauthSettings.urlRedirect');
+    const errorFree = !isError(this.state.error);
+
+    if (settings.length) {
+      let newSettings = [...settings];
+      let newValues = { ...values, urlRedirect: errorFree ? 'Loading...' : 'Not Available' };
+
+      if (redirectUrl && errorFree) {
+        newValues.urlRedirect = redirectUrl;
+        newSettings = newSettings.map(el => (el.name === 'urlRedirect' ? { ...el, defaultValue: redirectUrl } : el));
+      }
+
+      let formRef;
+      return (
+        <div className={'settings'}>
+          <SettingsForm
+            settings={newSettings}
+            values={newValues}
+            ref={ref => formRef = ref}
+            onSubmit={this.onSettings.bind(this)}
+          />
+          <button className={'btn-action'} onClick={() => formRef.submit()}>Update Settings</button>
+        </div>
+      );
+    }
+
+    finishInstall(null)
+      .then(({ onStatus }) => onStatus())
+      .catch(error => new Error(error));
+    return null;
+  }
+}

--- a/src/installer/javascript/index.js
+++ b/src/installer/javascript/index.js
@@ -1,0 +1,4 @@
+
+import ScreenSettings from './ScreenSettings';
+
+export default ScreenSettings;

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,0 +1,5 @@
+
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+
+configure({ adapter: new Adapter() });

--- a/src/test/unit/ScreenSettings.test.jsx
+++ b/src/test/unit/ScreenSettings.test.jsx
@@ -1,0 +1,92 @@
+
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+import ScreenSettings from '../../installer/javascript/ScreenSettings';
+
+const TestComponent = () => <div className="dummyForm" />
+
+test('render the settings screen in loading state', done => {
+
+  const props = {
+    finishInstall: () => Promise.resolve({ onStatus: () => {} }),
+    installType: 'install',
+    settings: ['test'],
+    values: [],
+    settingsForm: TestComponent,
+    dpapp: {
+      oauth: {
+        settings: (val) => new Promise((resolve, reject) => { // Keep promise pending
+          if (val === '') return resolve();
+          else if (val === '') return reject();
+        })
+      }
+    }
+  };
+
+  const wrapper = mount(<ScreenSettings {...props} />);
+
+  expect(wrapper.state('oauthSettings')).toBeNull();
+  expect(wrapper.state('error')).toBeNull();
+  expect(wrapper.find('TestComponent').prop('values').urlRedirect).toBe('Loading...');
+
+  wrapper.unmount();
+  done();
+});
+
+test('render the settings screen in error state', done => {
+
+  const props = {
+    finishInstall: () => Promise.resolve({ onStatus: () => {} }),
+    installType: 'install',
+    settings: ['test'],
+    values: [],
+    settingsForm: TestComponent,
+    dpapp: {
+      oauth: {
+        settings: () => Promise.reject(new Error())
+      }
+    }
+  };
+
+  const wrapper = mount(<ScreenSettings {...props} />);
+
+  expect(wrapper.state('oauthSettings')).toBeNull();
+  expect(wrapper.state('error')).toBeNull();
+
+  wrapper.setState({ oauthSettings: null, error: new Error() }, () => {
+    expect(wrapper.state('oauthSettings')).toBeNull();
+    expect(wrapper.state('error')).toBeInstanceOf(Error);
+    expect(wrapper.find('TestComponent').prop('values').urlRedirect).toBe('Not Available');
+    done();
+  });
+});
+
+test('render the settings screen in successful ready state', done => {
+
+  const props = {
+    finishInstall: () => Promise.resolve({ onStatus: () => {} }),
+    installType: 'install',
+    settings: ['test'],
+    values: [],
+    settingsForm: TestComponent,
+    dpapp: {
+      oauth: {
+        settings: () => Promise.resolve({ urlRedirect: 'test' })
+      }
+    }
+  };
+
+  const wrapper = mount(<ScreenSettings {...props} />);
+
+  expect(wrapper.state('oauthSettings')).toBeNull();
+  expect(wrapper.state('error')).toBeNull();
+
+  wrapper.setState({ oauthSettings: { urlRedirect: 'test' }, error: null }, () => {
+    expect(wrapper.state('oauthSettings').urlRedirect).toBe('test');
+    expect(wrapper.state('error')).toBeNull();
+    expect(wrapper.find('TestComponent').prop('values').urlRedirect).toBe('test');
+
+    done();
+  });
+});

--- a/src/test/unit/__snapshots__/App.test.jsx.snap
+++ b/src/test/unit/__snapshots__/App.test.jsx.snap
@@ -2,6 +2,6 @@
 
 exports[`successfully render the application in initial state 1`] = `
 <div>
-  Hello world
+  hello Youtrack world!
 </div>
 `;


### PR DESCRIPTION
Add initial ScreenSettings React component
Add Enzyme test utility for testing Settings components' state, props, output etc..
Add startupFiles field to .jestrc.json pointing to a setup file for Enzyme to play nice with Jest
Add unit tests for Settings components' loading, error, ready states
Add settings field and properties to package.json for use in ScreenSettings React component