### PR TITLE
feature/DP-753: Delete issue API

### DIFF
--- a/src/main/javascript/api.js
+++ b/src/main/javascript/api.js
@@ -1,22 +1,33 @@
 
 import { API_URL } from './constants'
-import { get, put, notEmpty } from './utils';
+import { get, put, del, notEmpty } from './utils';
 
 /**
  * Returns a promise which resolves with a list of issues
  *
  * @returns { Promise }
  */
-export const youtrackFetchIssues = () => get(`${API_URL}/issue`);
+export const fetchIssues = () => get(`${API_URL}/issue`);
 
 /**
  * Returns a promise which resolves with a success or failure in creating a Youtrack issue
  *
  * @returns { Promise }
  */
-export const youtrackCreateIssue = (data = {}) => {
+export const createIssue = (data = {}) => {
   const { project = '', summary = '', desc = '' } = data;
   return notEmpty(project) && notEmpty(summary) && notEmpty(desc) ?
     put(`${API_URL}/issue?project=${project}&summary=${summary}&description=${desc}`) :
-    Promise.reject(JSON.stringify({ message: 'Missing or misspelt parameters: project, summary, desc' }));
+    Promise.reject(JSON.stringify({ message: 'Missing parameters: project, summary, desc' }));
+}
+
+/**
+ * Returns a promise which resolves with a success or failure in deleting a Youtrack issue
+ *
+ * @returns { Promise }
+ */
+export const deleteIssue = (issue = '') => {
+  return notEmpty(issue) ?
+    del(`${API_URL}/issue/${issue}`) :
+    Promise.reject(JSON.stringify({ message: 'Missing parameter: issue' }));
 }

--- a/src/main/javascript/utils.js
+++ b/src/main/javascript/utils.js
@@ -33,6 +33,7 @@ const notEmpty = val => {
 };
 
 module.exports = {
+
   isDefined,
 
   exists,
@@ -54,6 +55,16 @@ module.exports = {
   get: (reqURL = '', headers = {}) => {
     return new Promise ((resolve, reject) => {
       fetch(reqURL, buildReqObj({ method: 'GET', headers }))
+        .then(status)
+          .then(json)
+            .then(resolve)
+            .catch(reject);
+    });
+  },
+
+  del: (reqURL = '', data = {}, headers = {}) => {
+    return new Promise ((resolve, reject) => {
+      fetch(reqURL, buildReqObj({ method: 'DELETE', body: JSON.stringify(data), headers }))
         .then(status)
           .then(json)
             .then(resolve)

--- a/src/test/unit/api.test.js
+++ b/src/test/unit/api.test.js
@@ -1,11 +1,11 @@
 
-import { youtrackFetchIssues, youtrackCreateIssue } from '../../main/javascript/api';
+import { fetchIssues, createIssue, deleteIssue } from '../../main/javascript/api';
 import { fixtures } from './api.fixtures.js'
 
 test('successfully retrieve issues', done => {
   fetch.mockResponse(JSON.stringify(fixtures));
 
-  return youtrackFetchIssues().then(resp => {
+  return fetchIssues().then(resp => {
       expect(resp).toEqual(fixtures);
 
       fetch.resetMocks();
@@ -17,7 +17,7 @@ test('unsuccessfully retrieve issues', done => {
   const error = { message: "There was an error" };
   fetch.mockReject(error);
 
-  return youtrackFetchIssues()
+  return fetchIssues()
     .then(resp => { done(); })
     .catch(err => {
       expect(err).toEqual(error);
@@ -36,7 +36,7 @@ test('successfully create an issue with a fully payload', done => {
   };
   fetch.mockResponse(JSON.stringify({ message: success.message, payload }));
 
-  return youtrackCreateIssue(payload)
+  return createIssue(payload)
     .then(resp => {
       expect(resp.message).toEqual(success.message);
       expect(resp.payload).toEqual(payload);
@@ -48,9 +48,9 @@ test('successfully create an issue with a fully payload', done => {
 });
 
 test('unsuccessfully create an issue without a payload', done => {
-  const error = { message: 'Missing or misspelt parameters: project, summary, desc' };
+  const error = { message: 'Missing parameters: project, summary, desc' };
 
-  return youtrackCreateIssue()
+  return createIssue()
     .then(resp => { done(); })
     .catch(err => {
       err = JSON.parse(err);
@@ -69,7 +69,53 @@ test('unsuccessfully create an issue', done => {
   };
   fetch.mockReject(JSON.stringify({ message: error.message, payload }));
 
-  return youtrackCreateIssue(payload)
+  return createIssue(payload)
+    .then(resp => { done(); })
+    .catch(err => {
+      err = JSON.parse(err);
+      expect(err.message).toEqual(error.message);
+      expect(err.payload).toEqual(payload);
+
+      fetch.resetMocks();
+      done();
+    });
+});
+
+test('successfully delete an issue with a fully payload', done => {
+  const success = { message: 'An issue was successfully deleted' };
+  const payload = 'TST-123';
+  fetch.mockResponse(JSON.stringify({ message: success.message, payload }));
+
+  return deleteIssue(payload)
+    .then(resp => {
+      expect(resp.message).toEqual(success.message);
+      expect(resp.payload).toEqual(payload);
+
+      fetch.resetMocks();
+      done();
+    })
+    .catch(err => { done(); });
+});
+
+test('unsuccessfully delete an issue without a payload', done => {
+  const error = { message: 'Missing parameter: issue' };
+
+  return deleteIssue()
+    .then(resp => { done(); })
+    .catch(err => {
+      err = JSON.parse(err);
+      expect(err.message).toEqual(error.message);
+
+      done();
+    });
+});
+
+test('unsuccessfully delete an issue', done => {
+  const error = { message: 'There was an error' };
+  const payload = 'TST-123';
+  fetch.mockReject(JSON.stringify({ message: error.message, payload }));
+
+  return deleteIssue(payload)
     .then(resp => { done(); })
     .catch(err => {
       err = JSON.parse(err);


### PR DESCRIPTION
Add del fetch method to utils so that a client can delete an issue
Add deleteIssue to Youtrack api and accompanying tests/fixtures
Rename API methods youtrackFetchIssues and youtrackCreateIssue to fetchIssues and createIssue
Amend response messages in tests to reflect correct context