### PR TITLE
- default `process.env.NODE_ENV` to `production`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ This project is following [Semantic Versioning](http://semver.org)
 
 ## [Unreleased][]
 
+## [0.1.0-beta.2][] - 2018-02-09
+
+ - default `process.env.NODE_ENV` to `production` when packaging the app for distribution with webpack  
+
 ## [0.1.0-beta.1][] - 2018-02-07
 
  - add support for viewing and creating Youtrack issues.
 
-[Unreleased]: https://github.com/DeskproApps/youtrack/compare/v0.1.0-beta.1...HEAD
+[Unreleased]: https://github.com/DeskproApps/youtrack/compare/v0.1.0-beta.2...HEAD
+[0.1.0-beta.2]: https://github.com/DeskproApps/youtrack/compare/v0.1.0-beta.1...v0.1.0-beta.2
 [0.1.0-beta.1]: https://github.com/DeskproApps/youtrack/tree/v0.1.0-beta.1

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskpro/apps-youtrack",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskpro/apps-youtrack",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "This application adds support for viewing and creating Youtrack issues.",
   "main": "lib/main/javascript/index.js",
   "scripts": {

--- a/src/webpack/webpack.config-distribution.js
+++ b/src/webpack/webpack.config-distribution.js
@@ -5,7 +5,8 @@ module.exports = function (env) {
   
   const PROJECT_ROOT_PATH = env && env.DP_PROJECT_ROOT ? env.DP_PROJECT_ROOT : path.resolve(__dirname, '../../');
   const DEBUG = env && env.NODE_ENV === 'development';
-  
+  const ENVIRONMENT =  env && env.NODE_ENV ? env.NODE_ENV : 'production';
+
   const buildManifest = new dpat.BuildManifest(
     PROJECT_ROOT_PATH,
     { distributionType: 'production', packagingType: 'cdn' }
@@ -67,7 +68,8 @@ module.exports = function (env) {
       
       new dpat.Webpack.DefinePlugin({
         DEBUG: DEBUG,
-        DPAPP_MANIFEST: JSON.stringify(buildManifest.getContent())
+        DPAPP_MANIFEST: JSON.stringify(buildManifest.getContent()),
+        'process.env.NODE_ENV': JSON.stringify(ENVIRONMENT)
       }),
       
       // for stable builds, in production we replace the default module index with the module's content hashe


### PR DESCRIPTION
- default `process.env.NODE_ENV` to `production` when packaging the app for distribution with webpack