### PR TITLE
Uses @deskpro/redux-components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ This project is following [Semantic Versioning](http://semver.org)
 
 ## [Unreleased][]
 
+- uses @deskpro/redux-components
+
 ## [0.1.0-beta.5][] - 2018-03-02
 
-* Added support for searching for issues
+- Added support for searching for issues
 
 ## [0.1.0-beta.4][] - 2018-02-26
 

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
   },
   "dependencies": {
     "@deskpro/react-components": "1.3.10",
+    "@deskpro/redux-components": "^1.0.1",
     "prop-types": "^15.5.10",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",

--- a/src/main/javascript/ui/TabCreateIssue.jsx
+++ b/src/main/javascript/ui/TabCreateIssue.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { sdkConnect } from '@deskpro/apps-sdk-react';
-import { Container, Heading, Group, SearchInline } from '@deskpro/react-components';
-import { reduxForm } from '@deskpro/react-components/dist/bindings';
+import { Container, Heading, Group, SearchInline, Button } from '@deskpro/react-components';
+import { Form, Select, Input, Textarea } from '@deskpro/redux-components';
 import { searchIssues } from '../api';
-
-const { Form, Select, Input, Textarea, Button } = reduxForm;
 
 class TabCreateIssue extends React.PureComponent {
 


### PR DESCRIPTION
The redux-form stuff in `@deskpro/react-components` is deprecated, and moved into `@deskpro/redux-components`.