### PR TITLE
[Bug] Remove Unwanted Header Elements When Viewing Linked Issues

### DIFF
--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -16,8 +16,10 @@ const HomePage: FC = () => {
   useSetTitle("YouTrack Issues");
   useSetBadgeCount(issues);
 
-  useDeskproElements(({ registerElement, clearElements }) => {
+  useDeskproElements(({ registerElement, deRegisterElement, clearElements }) => {
     clearElements();
+    deRegisterElement("edit")
+    deRegisterElement("home")
 
     registerElement("refresh", { type: "refresh_button" });
     registerElement("plus", {


### PR DESCRIPTION
## Description
This PR fixes a bug where the edit and home buttons persisted on the home page if the user refreshed the app while viewing an issue.

## Evidence
### Before

![image](https://github.com/user-attachments/assets/e6c81ddb-6aa8-4cb2-a885-7b2b7bcd553e)


### After

![image](https://github.com/user-attachments/assets/33d8ccf4-826b-44ff-ad6f-2220a47fd124)
